### PR TITLE
Fix broken spawn chunk removal on `/setworldspawn` in 1.20.5+

### DIFF
--- a/src/main/java/ru/vidtu/ksyxis/mixin/ServerLevelMixin.java
+++ b/src/main/java/ru/vidtu/ksyxis/mixin/ServerLevelMixin.java
@@ -107,7 +107,7 @@ public final class ServerLevelMixin {
 
             // Obfuscated.
             "method_8554(Lnet/minecraft/class_2338;F)V" // Fabric Intermediary
-    }, at = @At("STORE"), remap = false, require = 0, expect = 0, index = 5)
+    }, at = @At("STORE"), remap = false, require = 0, expect = 0, index = 4)
     private int ksyxis_setDefaultSpawnPos_spawnChunkRadius_getInt(final int spawnChunks) {
         // Assert.
         if (Variables.DEBUG_ASSERTS) {


### PR DESCRIPTION
Corrects a Local Variable Table (LVT) index typo in `ServerLevelMixin` (`5` to `4`). Previously, the injection silently failed to apply, which meant setting a new world spawn location in modern versions would unintentionally load the full spawn chunk radius into memory, defeating the mod's core purpose.